### PR TITLE
Add ability to obey Flask's autoescape in context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 docs/_build
 Flask_Markdown.egg-info
+*.pyc

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -56,6 +56,8 @@ API Reference
 .. autoclass:: Markdown
    :members:
 
+.. autofunction:: markdown_filter
+
 .. _`Flask`: http://flask.pocoo.org/
 .. _`Markdown`: http://www.freewisdom.org/projects/python-markdown/
 .. _`Github`: http://www.github.com/dcolish/flask-markdown

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,15 +1,16 @@
 from flask import Flask, render_template_string
-
+from nose.tools import with_setup
 
 from flaskext.markdown import Extension, Markdown
 from mdx_simple import SimpleExtension, SimplePreprocessor
 
 app = Flask(__name__)
 app.debug = True
-md = Markdown(app)
+autoescape_default = False
+md = Markdown(app,
+              autoescape=autoescape_default)
 
-
-def run_client():
+def setup():
 
     @app.route('/test_inline')
     def view_render_inline():
@@ -51,34 +52,79 @@ This is now a paragraph div
 ]]]"""
         return render_template_string(u"{{ text|markdown }}", text=text)
 
-    return app.test_client()
+    @app.route('/test_autoescape_off')
+    def view_render_autoescape_off():
+        mystr = u'This is a <b>markdown</b> block'
+        result = render_template_string(('{% autoescape false %}'
+                                         '{{mystr|markdown}}'
+                                         '{% endautoescape %}'), mystr=mystr)
+        return result
+
+    @app.route('/test_autoescape_on')
+    def view_render_autoescape_on():
+        mystr = u'This is a <b>markdown</b> block'
+        result = render_template_string(('{% autoescape true %}'
+                                         '{{mystr|markdown}}'
+                                         '{% endautoescape %}'), mystr=mystr)
+        return result
+
+
+def inject_autoescape_true():
+    app.config['markdown_autoescape'] = True
+
+
+def inject_autoescape_false():
+    app.config['markdown_autoescape'] = False
+
+
+def inject_autoescape_default():
+    app.config['markdown_autoescape'] = autoescape_default
 
 
 def test_render_inline():
-    client = run_client()
-    resp = client.open('/test_inline')
+    resp = app.test_client().open('/test_inline')
     assert resp.data == '<p>This is <em>markdown</em></p>'
 
 
 def test_render_var_block():
-    client = run_client()
-    resp = client.open('/test_var_block')
+    resp = app.test_client().open('/test_var_block')
     assert resp.data == '<p>This is a <em>markdown</em> block</p>'
 
 
 def test_render_in_block():
-    client = run_client()
-    resp = client.open('/test_in_block')
+    resp = app.test_client().open('/test_in_block')
     assert resp.data == '<p>This is a <em>markdown</em> block</p>'
 
 
 def test_render_register_extension():
-    client = run_client()
-    resp = client.open('/test_register')
+    resp = app.test_client().open('/test_register')
     assert resp.data == "<div><p>This is now a paragraph div</p></div>"
 
 
 def test_render_extend_decorator():
-    client = run_client()
-    resp = client.open('/test_extend')
+    resp = app.test_client().open('/test_extend')
     assert resp.data == "<div><p>This is now a paragraph div</p></div>"
+
+
+@with_setup(inject_autoescape_true, inject_autoescape_default)
+def test_render_autoescape_off_obey():
+    resp = app.test_client().open('/test_autoescape_off')
+    assert resp.data == "<p>This is a <b>markdown</b> block</p>"
+
+
+@with_setup(inject_autoescape_true, inject_autoescape_default)
+def test_render_autoescape_on_obey():
+    resp = app.test_client().open('/test_autoescape_on')
+    assert resp.data == "<p>This is a &lt;b&gt;markdown&lt;/b&gt; block</p>"
+
+
+@with_setup(inject_autoescape_false, inject_autoescape_default)
+def test_render_autoescape_off_ignore():
+    resp = app.test_client().open('/test_autoescape_off')
+    assert resp.data == "<p>This is a <b>markdown</b> block</p>"
+
+
+@with_setup(inject_autoescape_false, inject_autoescape_default)
+def test_render_autoescape_on_ignore():
+    resp = app.test_client().open('/test_autoescape_on')
+    assert resp.data == "<p>This is a <b>markdown</b> block</p>"


### PR DESCRIPTION
Default behavior is unchanged with this patch. If the user passes `autoescape=True` to the Markdown constructor, the Markdown filter will now obey autoescape in the evaluation context of the template. This covers both the default autoescape instituted by Flask for templates with certain extensions, and explicit autoescape control using `{% autoescape %}`.

Also added docs and tests to cover both new and default behaviors.

Please let me know what changes you would like to see; I'm a fairly junior developer, but would be happy to fix my own mistakes so you don't have to. Particularly with the issue of where to store the Markdown instance and autoescape option, currently shoved into the Flask app config globals.
