### PR TITLE
Fixed serious performance issue.

### DIFF
--- a/flaskext/markdown.py
+++ b/flaskext/markdown.py
@@ -76,7 +76,7 @@ class Markdown(object):
             'markdown', self.__build_filter(self.auto_escape))
 
     def __call__(self, stream):
-        return Markup(self._instance.convert(stream))
+        return Markup(self._instance.reset().convert(stream))
 
     def __build_filter(self, app_auto_escape):
         @evalcontextfilter


### PR DESCRIPTION
The more this extension was used to convert documents, the slower the conversion would take. This could end up causing a single, small document to take 14 seconds to convert, making the site unusably slow.

See waylan/Python-Markdown#305 for some more information on this.
